### PR TITLE
fixed: 画廊分类为Private会导致无法加载

### DIFF
--- a/scripts/utility.js
+++ b/scripts/utility.js
@@ -127,6 +127,10 @@ function getNameAndColor(name) {
     western: {
       string: "Western",
       color: "#AB9F60"
+    },
+    private: {
+      string: "Private",
+      color: "#000"
     }
   };
   return d[name.toLowerCase()];


### PR DESCRIPTION
收藏中可能会含有私有画廊，会导致列表无法加载
```
"message": "undefined is not an object (evaluating 'utility.getNameAndColor(item[\"category\"])[\"string\"]')"
```
找了一个[测试画廊(NSFW)](https://exhentai.org/g/348389/8fca7edcc3/)